### PR TITLE
Broaden the scope of getConsent function to allow single letter input

### DIFF
--- a/nginx-auto-config.go
+++ b/nginx-auto-config.go
@@ -31,7 +31,7 @@ func main() {
 		if os.Args[1] == "-h" || os.Args[1] == "-help" || os.Args[1] == "--help" {
 			fmt.Println("nginx-auto-config is a program which allows you to create configurations for the nginx web server using a number of presets interactively\nLicensed under the MIT license, created by Sidharth Soni (Sid Sun)\nYou can find the source code at: https://github.com/Sid-Sun/nginx-auto-config")
 		} else if os.Args[1] == "version" {
-			fmt.Printf("3.0\n")
+			fmt.Printf("3.1\n")
 		} else {
 			fmt.Printf("Unknown option(s) %s, run with -h, -help or --help to get help or without any argumets to launch the program\n", os.Args[1])
 		}
@@ -81,15 +81,15 @@ func main() {
 	if server.selection == 9 {
 		return
 	}
-	fmt.Print("Do you want the virtual server to send HSTS preload header with the response? (yes/no): ")
-	_, _ = cyan.Print("\nSend HSTS Preload header (yes/no): ")
+	fmt.Print("Do you want the virtual server to send HSTS preload header with the response? (Y[es]/N[o]): ")
+	_, _ = cyan.Print("\nSend HSTS Preload header (Y[es]/N[o]): ")
 	server.additional.addHSTSConfig = getConsent()
-	fmt.Print("Do you want to add additional security options to the config? (should not but may break the config) (yes/no): ")
-	_, _ = cyan.Print("\nAdd security config (yes/no): ")
+	fmt.Print("Do you want to add additional security options to the config? (should not but may break the config) (Y[es]/N[o]): ")
+	_, _ = cyan.Print("\nAdd security config (Y[es]/N[o]): ")
 	server.additional.addSecurityConfig = getConsent()
 	fileName, fileContents := PrepareServiceFileContents(server)
 	fmt.Print(fileContents)
-	_, _ = cyan.Print("Is this correct? (yes/no): ")
+	_, _ = cyan.Print("Is this correct? (Y[es]/N[o]): ")
 	if getConsent() {
 		writeContentToFile(fileName+".nginxAutoConfig.conf", fileContents)
 		if server.port == 443 {

--- a/utils.go
+++ b/utils.go
@@ -36,7 +36,8 @@ func getInput(EmptyAllowed bool, SingleWorded bool) string {
 }
 
 func getConsent() bool {
-	if strings.ToLower(getInput(false, true)) == "yes" {
+	consent := string([]rune(getInput(false, true))[:1])
+	if strings.ToLower(consent) == "y" {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: black.dragon74 <nickk.2974@gmail.com>

There are often cases where users mostly want to get away with just typing `y or n` as a reply to `yes or no` prompts. Almost all the popular programs have support for this, why shouldn't this awesome program have it too?

This approach works for both of the cases `yes or y` and `no or n` however, it does not check if you actually fully type `yes` or not. It will just select and compare the first letter. If it is `y` it means you agreed to the consent.