### PR TITLE
Enforce server root dir existence with an optional opt-out arg

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           chmod +x built-binary/nginx-auto-config
-          export version=`built-binary/nginx-auto-config version`
+          export version=`built-binary/nginx-auto-config -v`
           export folder=`echo nginx-auto-config_amd64`
           echo "export version=\"$version\"" > env.file
           echo "export folder=\"$folder\"" >> env.file
@@ -122,7 +122,7 @@ jobs:
         shell: bash
         run: |
           sudo dpkg -i debian-package/nginx-auto-config_amd64.deb
-          export version=`nginx-auto-config version`
+          export version=`nginx-auto-config -v`
           echo "export version=\"$version\"" > env.file
 
       - name: Get assets and decrypt data

--- a/nginx-auto-config.go
+++ b/nginx-auto-config.go
@@ -114,7 +114,6 @@ func main() {
 		if server.port == 443 {
 			printCautionSSL()
 		}
-		os.Exit(0)
 	}
 
 	os.Exit(0)

--- a/nginx-auto-config.go
+++ b/nginx-auto-config.go
@@ -41,9 +41,9 @@ func main() {
 			fmt.Println(sVers)
 		} else {
 			fmt.Printf(
-					"Unknown option(s) %s\n" +
+					"Unknown option: %s\n" +
 						"Run with -h, -help or --help to get help\n" +
-						"-v or version to get program version\n" +
+						"-v, -version or --version to get program version\n" +
 						"Or without any argumets to launch the program interactively\n", pArg)
 			os.Exit(1)
 		}
@@ -228,16 +228,4 @@ func takeInput() int {
 		return takeInput()
 	}
 	return input
-}
-
-func verifyDirInput() string {
-	dirName := getInput(false, false)
-
-	if !dirExists(dirName) {
-		_, _ = red.Printf("Directory '%v' is non existent, please try again.\n", dirName)
-		_, _ = cyan.Print("Root path: ")
-		return verifyDirInput()
-	} else {
-		return dirName
-	}
 }

--- a/nginx-auto-config.go
+++ b/nginx-auto-config.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const sVers string = "4.0"	// Program Version
+
 type service struct {
 	selection  int
 	domains    string
@@ -30,22 +32,22 @@ var red = color.New(color.FgRed)
 
 func main() {
 	var server service
-	server.verifyRoot = true
 
 	if len(os.Args) > 1 {
-		pArgs := os.Args[1]
-		if pArgs == "-h" || pArgs == "-help" || pArgs == "--help" {
+		pArg := os.Args[1]
+		if pArg == "-h" || pArg == "-help" || pArg == "--help" {
 			fmt.Println("nginx-auto-config is a program which allows you to create configurations for the nginx web server using a number of presets interactively\nLicensed under the MIT license, created by Sidharth Soni (Sid Sun)\nYou can find the source code at: https://github.com/Sid-Sun/nginx-auto-config")
-			os.Exit(0)
-		} else if pArgs == "version" {
-			fmt.Printf("3.2\n")
-			os.Exit(0)
-		} else if pArgs == "-skiproot" || pArgs == "-s" || pArgs == "--skiproot" {
-			server.verifyRoot = false
+		} else if pArg == "--version" || pArg == "-v" || pArg == "-version" {
+			fmt.Println(sVers)
 		} else {
-			fmt.Printf("Unknown option(s) %s, run with -h, -help or --help to get help, -s, -skiproot or --skiproot to skip server root directory validation or without any argumets to launch the program\n", pArgs)
+			fmt.Printf(
+					"Unknown option(s) %s\n" +
+						"Run with -h, -help or --help to get help\n" +
+						"-v or version to get program version\n" +
+						"Or without any argumets to launch the program interactively\n", pArg)
 			os.Exit(1)
 		}
+		os.Exit(0)
 	}
 	fmt.Println("-------------------------------------------------------------------------------")
 	fmt.Println("An interactive program to Automate nginx virtual server creation by Sid Sun")
@@ -57,6 +59,8 @@ func main() {
 	testWritePermissions()
 	server.selection = takeInput()
 	server.port = 443
+	_, _ = cyan.Print("Are you creating this configuration to deploy on this machine? Y[es]/N[o]: ")
+	server.verifyRoot = getConsent()
 	if inRange(server.selection, []int{1, 2, 3, 4, 5, 6, 7}) {
 		fmt.Println("Enter the domain/sub-domain name(s) (separated by space and without ending semicolon)")
 		_, _ = cyan.Print("Server Names: ")
@@ -65,13 +69,13 @@ func main() {
 	if inRange(server.selection, []int{1, 2, 3, 4}) {
 		fmt.Println("Enter the path where the files are (root path for virtual server)")
 		_, _ = cyan.Print("Root path: ")
-		rootPath := getInput(false, false)
-		if server.verifyRoot && !dirExists(rootPath) {
-			_, _ = red.Printf("Server root directory: '%v' is non existent. Please try again\n", rootPath)
-			os.Exit(1)
+		var rootPath string
+		if server.verifyRoot {
+			rootPath = verifyDirInput()
 		} else {
-			server.root = rootPath
+			rootPath = getInput(false, false)
 		}
+		server.root = rootPath
 	}
 	if inRange(server.selection, []int{5, 6, 7}) {
 		if server.selection == 6 {
@@ -94,7 +98,7 @@ func main() {
 		server.port = 80
 	}
 	if server.selection == 9 {
-		os.Exit(1)
+		os.Exit(0)
 	}
 	fmt.Print("Do you want the virtual server to send HSTS preload header with the response? (Y[es]/N[o]): ")
 	_, _ = cyan.Print("\nSend HSTS Preload header (Y[es]/N[o]): ")
@@ -224,4 +228,16 @@ func takeInput() int {
 		return takeInput()
 	}
 	return input
+}
+
+func verifyDirInput() string {
+	dirName := getInput(false, false)
+
+	if !dirExists(dirName) {
+		_, _ = red.Printf("Directory '%v' is non existent, please try again.\n", dirName)
+		_, _ = cyan.Print("Root path: ")
+		return verifyDirInput()
+	} else {
+		return dirName
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -92,3 +92,18 @@ func writeContentToFile(fileName string, fileContents string) {
 func printCautionSSL() {
 	_, _ = yellow.Println("Caution: SSL config is commented out by default, please generate the key and point to it correctly as necessary.")
 }
+
+func dirExists(path string) bool {
+	// Stat the file
+	info, err := os.Stat(path)
+
+	// If there is error check if the file is non existent
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+
+	// Else check if the path is actually a directory and return accordingly
+	return info.IsDir()
+}

--- a/utils.go
+++ b/utils.go
@@ -112,7 +112,7 @@ func verifyDirInput() string {
 		_, _ = red.Printf("Directory '%v' is non existent, please try again.\n", dirName)
 		_, _ = cyan.Print("Root path: ")
 		return verifyDirInput()
-	} else {
-		return dirName
 	}
+
+	return dirName
 }

--- a/utils.go
+++ b/utils.go
@@ -104,3 +104,15 @@ func dirExists(path string) bool {
 	// Else check if the path is actually a directory and return accordingly
 	return info.IsDir()
 }
+
+func verifyDirInput() string {
+	dirName := getInput(false, false)
+
+	if !dirExists(dirName) {
+		_, _ = red.Printf("Directory '%v' is non existent, please try again.\n", dirName)
+		_, _ = cyan.Print("Root path: ")
+		return verifyDirInput()
+	} else {
+		return dirName
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -37,10 +37,7 @@ func getInput(EmptyAllowed bool, SingleWorded bool) string {
 
 func getConsent() bool {
 	consent := string([]rune(getInput(false, true))[:1])
-	if strings.ToLower(consent) == "y" {
-		return true
-	}
-	return false
+	return strings.ToLower(consent) == "y"
 }
 func getInt() int {
 	input, err := strconv.Atoi(getInput(false, true))


### PR DESCRIPTION
By default the program will now verify if the server root directory really exists or not. It can help nullify the cases where the config file simply won't work because of a typo in the root dir path.

However there might be cases where the user is trying to create config file to use on a separate machine in such cases the validation can easily be skipped by using `-s` or `-skiproot` or `--skiproot` args.

This commit also refactors some code and enforces proper exit methods instead of using the improper `return` keyword.