### PR TITLE
Convert relative filepath to absolute file path

### DIFF
--- a/nginx-auto-config.go
+++ b/nginx-auto-config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const sVers string = "4.2"	// Program Version
+const sVers string = "4.3"	// Program Version
 
 type service struct {
 	selection  int

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	pathlib "path"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -112,6 +114,12 @@ func verifyDirInput() string {
 		_, _ = red.Printf("Directory '%v' is non existent, please try again.\n", dirName)
 		_, _ = cyan.Print("Root path: ")
 		return verifyDirInput()
+	}
+
+	// If the dirname is not absloute path, return a absloute path
+	if !pathlib.IsAbs(dirName) {
+		absPath, _ := filepath.Abs(dirName)
+		return absPath
 	}
 
 	return dirName

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	pathlib "path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -116,11 +115,7 @@ func verifyDirInput() string {
 		return verifyDirInput()
 	}
 
-	// If the dirname is not absloute path, return a absloute path
-	if !pathlib.IsAbs(dirName) {
-		absPath, _ := filepath.Abs(dirName)
-		return absPath
-	}
-
-	return dirName
+	// Return a absloute path
+	absPath, _ := filepath.Abs(dirName)
+	return absPath
 }


### PR DESCRIPTION
Fixes issues  on *NIX systems where the config might not work due to `server -> root` being relative path instead of the absolute path.